### PR TITLE
adjust Antora TOC styles

### DIFF
--- a/boostlook.css
+++ b/boostlook.css
@@ -548,7 +548,7 @@ html.toc-hidden .boostlook:not(:has(.doc)) {
   top: 38%;
   width: 16px;
   height: 16px;
-  margin-left: -1rem;
+  margin-left: -1.25rem;
   background-image: var(--bl-caret-svg);
   background-repeat: no-repeat;
   background-position: center center;
@@ -568,6 +568,17 @@ html.toc-hidden .boostlook:not(:has(.doc)) {
 .boostlook .doc .content pre code {
   background-color: var(--bl-code-background);
   border-color: var(--bl-code-border-color);
+}
+
+/* Layout */
+.boostlook .article .content {
+  gap: 1rem;
+}
+
+/* Table of Contents */
+.boostlook .toc .toc-menu a {
+  border-left: 0;
+  padding: .25rem 0 0 0;
 }
 
 /*----------------- Styles specific to Antora Templates end -----------------*/


### PR DESCRIPTION
- add gap between article and TOC
- refine padding on TOC links
- move current-page nav icon further left

Addresses boostorg/website-v2-docs#317

**Preview**
![antora-ui-style-contents-panel-317-1](https://github.com/user-attachments/assets/0376376b-a6ce-40aa-b28d-bc9d6fe540ef)
![antora-ui-style-contents-panel-317-2](https://github.com/user-attachments/assets/2cae868a-fde3-40d2-9e61-201acdedae01)
