### PR TITLE
enhance boostlook layout and fix toc display on mobile

### DIFF
--- a/boostlook.css
+++ b/boostlook.css
@@ -373,7 +373,6 @@ p, h1, h2, h3, h4, h5, h6 {
   color: var(--bl-code-text-color) !important;
 }
 
-
 .boostlook .quoteblock,
 .boostlook .verseblock {
   background: var(--bl-quote-background);
@@ -445,6 +444,34 @@ p, h1, h2, h3, h4, h5, h6 {
   font-weight: bold;
 }
 
+.boostlook #header,
+.boostlook #content,
+.boostlook #footer {
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+}
+
+.boostlook #header {
+  padding-top: 1.25rem;
+  border-top-left-radius: 0.5rem;
+  border-top-right-radius: 0.5rem;
+}
+
+.boostlook #content {
+  padding-top: 1.25rem;
+  overflow-y: auto;
+}
+
+.boostlook #footer {
+  padding-bottom: 1.25rem;
+  border-bottom-left-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
+}
+
+.boostlook h2:first-of-type {
+  margin-top: 0;
+}
+
 /*----------------- Global Styles for .boostlook end -----------------*/
 
 /*----------------- Styles specific to AsciiDoctor content start -----------------*/
@@ -513,16 +540,20 @@ p, h1, h2, h3, h4, h5, h6 {
   font-size: 1.5rem;
 }
 
-.boostlook,
-.boostlook #toc.toc2 {
+.boostlook #toc.toc2,
+.boostlook #header:not(:has(.nav-container)),
+.boostlook #content,
+.boostlook #footer {
   background-color: var(--bl-card-background-color);
-  padding: 1rem 1.5rem;
+}
+
+.boostlook #toc.toc2,
+.boostlook #toc.toc2.nav-container {
+  overflow-y: auto;
 }
 
 .boostlook #toc.toc2 {
   position: static;
-  padding-left: 0;
-  overflow-y: auto;
 }
 
 .boostlook #toc.toc2 > ul {
@@ -573,10 +604,9 @@ p, h1, h2, h3, h4, h5, h6 {
   }
 
   .article.toc2.toc-left {
-    padding: 1rem;
+    padding: 1rem 1rem 0 1rem;
   }
 
-  .boostlook,
   .boostlook #toc.toc2 {
     border-radius: 0.5rem;
   }
@@ -587,7 +617,7 @@ p, h1, h2, h3, h4, h5, h6 {
     left: max(1rem, 50% - 39rem);
     top: 1rem;
     z-index: 1000;
-    height: calc(100vh - 2rem);
+    height: calc(100vh - 1rem);
     padding: 1rem;
     padding: 1rem 1rem 1.5rem;
     overflow-x: hidden;
@@ -668,6 +698,10 @@ p, h1, h2, h3, h4, h5, h6 {
 
 /*----------------- Styles specific to Antora Templates start -----------------*/
 
+.boostlook #header:has(.nav-container) {
+  padding: 0;
+}
+
 /* Typography */
 .boostlook .doc {
   line-height: 1.5rem;
@@ -726,11 +760,16 @@ p, h1, h2, h3, h4, h5, h6 {
   color: #828282;
 }
 
-/* TODO: Remove when docs wrapper is resolved in website-v2 */
-.source-docs-antora .boostlook #toc.toc2 {
-  top: 1rem !important;
-  max-height: calc(100vh - 1rem) !important;
-  padding: 1.25em 1.5em !important;
+.boostlook #toc.toc2.nav-container {
+  position: fixed;
+}
+
+.boostlook #header .nav-container.is-active {
+  padding: 1rem;
+}
+
+.boostlook #content .nav-toggle {
+  background-position-x: 0;
 }
 
 /* Active Page Indicator */
@@ -787,6 +826,10 @@ p, h1, h2, h3, h4, h5, h6 {
   display: flex;
 }
 
+.boostlook #footer:has(> script):not(:has(> div)) {
+  padding-top: 0;
+}
+
 /* Table of Contents */
 .boostlook .nav {
   height: 100%;
@@ -837,10 +880,21 @@ p, h1, h2, h3, h4, h5, h6 {
   color: var(--bl-text-color);
 }
 
-/* #libraryReadMe */
 
+/* Responsive Styles */
+@media screen and (min-width: 768px) {
+  .boostlook #content:has(> article.doc) {
+    border-top-right-radius: 0.5rem;
+    border-top-left-radius: 0.5rem;
+  }
+}
+
+/*----------------- Styles specific to Antora Templates end -----------------*/
+/*----------------- Styles specific to website-v2 start -----------------*/
+  
+/* Library/Releases Readmes */
 #libraryReadMe li p {
   display: inline;
 }
 
-/*----------------- Styles specific to Antora Templates end -----------------*/
+/*----------------- Styles specific to website-v2 end -----------------*/


### PR DESCRIPTION
- added padding and border-radius to #header, #content, and #footer
- refactored TOC with fixed position and overflow
- implemented conditional footer padding using :has()
- added media query for responsive border-radius on #content
- fixed TOC not displaying on mobile devices
- fixed styling issues for antora templates

addresses https://github.com/boostorg/website-v2-docs/issues/359