### PR TITLE
Bring styles over from boostbook; makes styling consistent across doc types

### DIFF
--- a/boostlook.css
+++ b/boostlook.css
@@ -63,7 +63,7 @@
 
   /* Light Theme Variables */
   --light-bl-background: rgb(255, 255, 255);
-  --light-bl-border-color: rgb(220, 220, 220);
+  --light-bl-border-color: rgb(209, 209, 209);
   --light-bl-breadcrumbs-svg-color: rgb(0, 0, 0);
   --light-bl-caret-svg: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20height='24px'%20viewBox='0%20-960%20960%20960'%20width='24px'%20fill='%23000000'%3E%3Cpath%20d='M320-200v-560l440%20280-440%20280Z'/%3E%3C/svg%3E");
   --light-bl-card-background-color: rgb(255, 255, 255);
@@ -72,6 +72,7 @@
   --light-bl-code-text-color: rgb(0, 0, 0);
   --light-bl-link-color: rgb(2, 132, 199);
   --light-bl-link-hover-color: rgba(255, 159, 0);
+  --light-bl-header-color: rgb(49, 74, 87);
   --light-bl-hljs-attribute-color: rgb(70, 130, 180);
   --light-bl-hljs-doctag-color: rgb(221, 17, 68);
   --light-bl-hljs-keyword-color: rgb(51, 51, 51);
@@ -92,7 +93,8 @@
   --light-bl-text-color: rgb(51, 65, 85);
 
   /* Dark Theme Variables */
-  --dark-bl-border-color: rgb(209, 228, 242);
+  --dark-bl-background: rgb(5, 26, 38);
+  --dark-bl-border-color: rgb(3, 25, 37);
   --dark-bl-breadcrumbs-svg-color: rgb(255, 255, 255);
   --dark-bl-caret-svg: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20height='24px'%20viewBox='0%20-960%20960%20960'%20width='24px'%20fill='%23ccc'%3E%3Cpath%20d='M320-200v-560l440%20280-440%20280Z'/%3E%3C/svg%3E");
   --dark-bl-card-background-color: rgb(23, 42, 52);
@@ -101,6 +103,7 @@
   --dark-bl-code-text-color: rgb(255, 255, 255);
   --dark-bl-link-color: rgb(125 211 252);
   --dark-bl-link-hover-color: rgb(255, 159, 0);
+  --dark-bl-header-color: rgb(255, 255, 255);
   --dark-bl-hljs-attribute-color: rgb(70, 130, 180);
   --dark-bl-hljs-doctag-color: rgb(255, 99, 132);
   --dark-bl-hljs-keyword-color: rgb(173, 216, 230);
@@ -120,6 +123,34 @@
   --dark-bl-table-stripe-color: rgb(49,74,87);
   --dark-bl-tabpanel-background: rgb(49 74 87);
   --dark-bl-text-color: rgb(255, 255, 255);
+
+  /* specific use colors */
+  --site-light-red: red;
+  --site-light-green: green;
+  --site-light-lime: #00FF00;
+  --site-light-blue: blue;
+  --site-light-navy: rgb(20, 20, 164);
+  --site-light-yellow: yellow;
+  --site-light-magenta: magenta;
+  --site-light-indigo: #4B0082;
+  --site-light-cyan: cyan;
+  --site-light-purple: purple;
+  --site-light-gold: #987301;
+  --site-light-silver: silver; /* lighter gray */
+  --site-light-gray: #808080; /* light gray */
+  --site-dark-red: #fa6f6f;
+  --site-dark-green: #45b945;
+  --site-dark-lime: #00FF00;
+  --site-dark-blue: #6666f8;
+  --site-dark-navy: #6060c4;
+  --site-dark-yellow: yellow;
+  --site-dark-magenta: magenta;
+  --site-dark-indigo: #a53def;
+  --site-dark-cyan: cyan;
+  --site-dark-purple: #ac43ac;
+  --site-dark-gold: gold;
+  --site-dark-silver: silver; /* lighter gray */
+  --site-dark-gray: #808080; /* light gray */
 }
 
 /*----------------- Root Variables - End -----------------*/
@@ -135,6 +166,7 @@ html {
   --bl-code-background: var(--light-bl-code-background);
   --bl-code-border-color: var(--light-bl-code-border-color);
   --bl-code-text-color: var(--light-bl-code-text-color);
+  --bl-header-color: var(--light-bl-header-color);
   --bl-hljs-doctag-color: var(--light-bl-hljs-doctag-color);
   --bl-hljs-attribute-color: var(--light-bl-hljs-attribute-color);
   --bl-hljs-keyword-color: var(--light-bl-hljs-keyword-color);
@@ -155,9 +187,25 @@ html {
   --bl-table-stripe-color: var(--light-bl-table-stripe-color);
   --bl-tabpanel-background: var(--light-bl-tabpanel-background);
   --bl-text-color: var(--light-bl-text-color);
+
+  /* specific use colors */
+  --color-red: var(--site-light-red);
+  --color-green: var(--site-light-green);
+  --color-lime: var(--site-light-lime);
+  --color-blue: var(--site-light-blue);
+  --color-navy: var(--site-light-navy);
+  --color-yellow: var(--site-light-yellow);
+  --color-magenta: var(--site-light-magenta);
+  --color-indigo: var(--site-light-indigo);
+  --color-cyan: var(--site-light-cyan);
+  --color-purple: var(--site-light-purple);
+  --color-gold: var(--site-light-gold);
+  --color-silver: var(--site-light-silver);/* lighter gray */
+  --color-gray: var(--site-light-gray); /* light gray */
 }
 
 html.dark {
+  --bl-background: var(--dark-bl-background);
   --bl-border-color: var(--dark-bl-border-color);
   --bl-breadcrumbs-svg-color: var(--dark-bl-breadcrumbs-svg-color);
   --bl-caret-svg: var(--dark-bl-caret-svg);
@@ -165,6 +213,7 @@ html.dark {
   --bl-code-background: var(--dark-bl-code-background);
   --bl-code-border-color: var(--dark-bl-code-border-color);
   --bl-code-text-color: var(--dark-bl-code-text-color);
+  --bl-header-color: var(--dark-bl-header-color);
   --bl-hljs-attribute-color: var(--dark-bl-hljs-attribute-color);
   --bl-hljs-doctag-color: var(--dark-bl-hljs-doctag-color);
   --bl-hljs-keyword-color: var(--dark-bl-hljs-keyword-color);
@@ -187,6 +236,21 @@ html.dark {
   --bl-table-stripe-color: var(--dark-bl-table-stripe-color);
   --bl-tabpanel-background: var(--dark-bl-tabpanel-background);
   --bl-text-color: var(--dark-bl-text-color);
+
+  /* specific use colors */
+  --color-red: var(--site-dark-red);
+  --color-green: var(--site-dark-green);
+  --color-lime: var(--site-dark-lime);
+  --color-blue: var(--site-dark-blue);
+  --color-navy: var(--site-dark-navy);
+  --color-yellow: var(--site-dark-yellow);
+  --color-magenta: var(--site-dark-magenta);
+  --color-indigo: var(--site-dark-indigo);
+  --color-cyan: var(--site-dark-cyan);
+  --color-purple: var(--site-dark-purple);
+  --color-gold: var(--site-dark-gold);
+  --color-silver: var(--site-dark-silver);/* lighter gray */
+  --color-gray: var(--site-dark-gray); /* light gray */
 }
 
 /*----------------- HTML Variables - End -----------------*/
@@ -349,6 +413,12 @@ p, h1, h2, h3, h4, h5, h6 {
 
 .boostlook h6:has(+table) {
   margin-left: 1em;
+}
+
+.boostlook ul.itemizedlist,
+#boost-legacy-docs-wrapper ul {
+  padding: 0 0 0 15px;
+  margin: 0;
 }
 
 .boostlook p code,
@@ -848,7 +918,7 @@ p, h1, h2, h3, h4, h5, h6 {
 
 /* Code Block */
 .boostlook .doc .content pre code {
-  background-color: var(--bl-code-background);
+  background-color: var(--bl-pre-background);
   border-color: var(--bl-code-border-color);
   color: var(--bl-code-text-color);
   border-radius: 8px;
@@ -944,7 +1014,8 @@ p, h1, h2, h3, h4, h5, h6 {
 
 
 /*---------- Quickbook docs styling fixes -----------*/
-#boost-legacy-docs-wrapper.boostlook p {
+#boost-legacy-docs-wrapper.boostlook p,
+.boostlook p {
   margin-bottom: 0;
   font-size: 16px;
 }
@@ -955,6 +1026,7 @@ p, h1, h2, h3, h4, h5, h6 {
 
 #boost-legacy-docs-wrapper.boostlook:not(:has(.doc)) th {
   background-color: var(--bg-color);
+  border-color: var(--bl-border-color);
 }
 
 .boostlook div.note,
@@ -968,6 +1040,7 @@ p, h1, h2, h3, h4, h5, h6 {
   border-radius: 8px;
   background-color: var(--bl-tabpanel-background);
   margin: 1pc 0 0 0;
+  padding: 8px;
 }
 
 .boostlook div.note table,
@@ -1022,6 +1095,22 @@ p, h1, h2, h3, h4, h5, h6 {
 .boostlook table h5,
 .boostlook table h6 {
   line-height: 1.75rem;
+}
+
+.boostlook:not(:has(.doc)) div.variablelist dl dt {
+    margin-bottom: 0.2em;
+    font-weight: bold;
+}
+
+.boostlook:not(:has(.doc)) div.variablelist dl dd {
+    margin: 0em 0em 0.5em 2em;
+    font-size: 10pt;
+}
+
+.boostlook:not(:has(.doc)) div.variablelist table tbody tr td p,
+.boostlook:not(:has(.doc)) div.variablelist dl dd p {
+    margin: 0em 0em 0.5em 0em;
+    line-height: 1;
 }
 
 .boostlook div.toc {
@@ -1097,3 +1186,226 @@ body > .chapter,
     top: 0.2rem;
   }
 }
+
+/* ---------------- Styling from boostbookV2.css ----------------*/
+
+body[bgcolor="white"]:has(.boostlook):not(:has(.doc)) {
+  background-color: transparent;
+}
+
+.boostlook:not(:has(.doc)) {
+  border-radius: 0;
+}
+/* general elements */
+.boostlook:not(:has(.doc)) h1,
+.boostlook:not(:has(.doc)) h2,
+.boostlook:not(:has(.doc)) h3,
+.boostlook:not(:has(.doc)) h4,
+.boostlook:not(:has(.doc)) h5,
+.boostlook:not(:has(.doc)) h6 {
+  margin: 1em 0em 0.5em;
+}
+
+.boostlook:not(:has(.doc)) h5 {
+  font-style: italic;
+  font-weight: normal;
+  font-size: 110%;
+}
+
+.boostlook:not(:has(.doc)) h1 a,
+.boostlook:not(:has(.doc)) h2 a,
+.boostlook:not(:has(.doc)) h3 a,
+.boostlook:not(:has(.doc)) h4 a {
+  color: var(--bl-header-color)
+}
+
+.boostlook:not(:has(.doc)) p {
+  padding: 1em 0 !important;
+}
+
+.boostlook:not(:has(.doc)) > hr {
+  display: none;
+}
+
+.boostlook:not(:has(.doc)) ol {
+  padding-left: 1em;
+}
+
+.boostlook:not(:has(.doc)) ol li {
+  list-style-type: decimal;
+}
+
+.boostlook:not(:has(.doc)) pre {
+  background-color: var(--bl-pre-background);
+  border: 1px solid var(--bl-code-border-color);
+  border-radius: 8px;
+  padding: 1.2em .8em
+}
+
+.boostlook:not(:has(.doc)) :not(.highlight) pre {
+  color: var(--bl-code-text-color);
+}
+
+.boostlook:not(:has(.doc)) div.informaltable table tr th,
+.boostlook:not(:has(.doc)) div.table table tr th {
+  border: 1px solid var(--bl-border-color);
+}
+
+/* spirit nav */
+.boostlook:not(:has(.doc)) .spirit-nav {
+  position: absolute;
+  top: 0.2rem;
+  right: calc(((100% - 75rem) / 2));
+  text-align: right;
+  margin: 0.75rem;
+  max-width: 80rem;
+  display: flex;
+}
+.boostlook:not(:has(.doc)) .spirit-nav a {
+  color: var(--secondary-color);
+  padding-left: 0.5em;
+}
+.boostlook:not(:has(.doc)) .spirit-nav img {
+  border-width: 0px;
+}
+.dark .boostlook:not(:has(.doc)) .spirit-nav img {
+  -webkit-filter: invert(100%); /* Safari/Chrome */
+  filter: invert(100%);
+}
+/* TOC */
+.boostlook:not(:has(.doc)) div.toc {
+  font-size: 80%;
+  line-height: 1.15;
+  color: var(--text-color);
+  border: 1px solid var(--bl-border-color);
+  background-color: var(--bl-pre-background);
+}
+
+.boostlook:not(:has(.doc)) div.toc dl.toc {
+  background-color: transparent;
+}
+
+.boostlook:not(:has(.doc)) #toc ul {
+  list-style: none !important;
+  margin: 0.5rem 0 !important;
+}
+
+.boostlook:not(:has(.doc)) .boost-toc {
+  float: right;
+  padding: 0.5pc;
+}
+
+/* Code on toc */
+.boostlook:not(:has(.doc)) .toc .computeroutput {
+  font-size: 120%
+}
+
+.boostlook:not(:has(.doc)) .copyright-footer {
+  text-align: right;
+  font-size: 70%;
+}
+
+.boostlook:not(:has(.doc)) .copyright-footer p {
+  text-align: left;
+  font-size: 10pt;
+  line-height: 1.15;
+}
+
+/* Syntax Highlighting */
+.property,
+.highlight .k,
+.highlight .kc,
+.highlight .kd,
+.highlight .kn,
+.highlight .kp,
+.highlight .kr,
+.highlight .kt,
+.keyword {
+  color: var(--color-purple);
+}
+
+.highlight .n,
+.highlight .na,
+.highlight .nb,
+.highlight .bp,
+.highlight .nc,
+.highlight .no,
+.highlight .nd,
+.highlight .ni,
+.highlight .ne,
+.highlight .nf,
+.highlight .py,
+.highlight .nl,
+.highlight .nn,
+.highlight .nx,
+.highlight .nt,
+.highlight .nv,
+.highlight .vc,
+.highlight .vg,
+.highlight .vi,
+.identifier {
+  color: var(--color-navy);
+}
+
+.special {
+  color: var(--text-color);
+}
+
+.highlight .cp,
+.preprocessor {
+  color: var(--color-blue);
+}
+
+.highlight .sc
+.char {
+  color: var(--color-lime);
+}
+
+.highlight .c,
+.highlight .ch,
+.highlight .cm,
+.highlight .cp,
+.highlight .cpf,
+.highlight .c1,
+.highlight .cs,
+.highlight .sd,
+.highlight .sh,
+.comment {
+  color: var(--color-green);
+}
+
+.highlight .s,
+.highlight .sa,
+.highlight .sb,
+.highlight .dl,
+.highlight .s2,
+.highlight .se,
+.highlight .si,
+.highlight .sx,
+.highlight .sr,
+.highlight .s1,
+.highlight .ss,
+.string {
+  color: var(--color-gold);
+}
+
+.highlight .m,
+.highlight .mf,
+.highlight .mh,
+.highlight .mi,
+.highlight .mo,
+.number {
+  color: var(--color-red);
+}
+
+.highlight,
+.white_bkd {
+  background-color: var(--card-color);
+}
+
+.highlight .hll,
+.dk_grey_bkd {
+  background-color: var(--border-color);
+}
+
+/* ---------------- Styling from boostbookV2.css end ----------------*/


### PR DESCRIPTION
https://github.com/boostorg/website-v2/issues/1484

These changes will allow the docs to maintain their styling after boostbookv2.css is removed