### PR TITLE
fix z-index on spirit nav #406

### DIFF
--- a/boostlook.css
+++ b/boostlook.css
@@ -1607,6 +1607,7 @@ body > .chapter,
   padding-left: 10px;
   max-width: 80rem;
   display: flex;
+  z-index: 5;
 }
 
 .boostlook:not(:has(.doc)) .spirit-nav a,


### PR DESCRIPTION
the spirit nav should be clickable when the h2 takes up the same space

https://github.com/boostorg/website-v2-docs/issues/406