### PR TITLE
refactor: optimize font sources in boostlook.css

### DIFF
--- a/boostlook.css
+++ b/boostlook.css
@@ -397,8 +397,8 @@ html.dark {
   font-variation-settings: "wght" 400;
   font-stretch: semi-condensed;
   font-display: block;             /* Prevents FOIT */
-  src: url('/_/fonts/NotoSansDisplay.ttf') format('truetype'),
-       url('../../../../tools/boostlook/NotoSansDisplay.ttf') format('truetype'),
+  src: url("/static/font/notosans.woff2") format("woff2"),
+       url("../../../../tools/boostlook/NotoSansDisplay.ttf") format('truetype'),
        url("https://cppalliance.org/fonts/NotoSansDisplay.ttf") format('truetype');
 }
 
@@ -410,7 +410,7 @@ html.dark {
   font-variation-settings: "wght" 400;
   font-stretch: semi-condensed;
   font-display: block;             /* Prevents FOIT */
-  src: url("/font/NotoSansDisplay-Italic.ttf") format("truetype"),
+  src: url("/static/font/notosans_italic.woff2") format("woff2"),
        url("../../../../tools/boostlook/NotoSansDisplay-Italic.ttf") format("truetype"),
        url("https://cppalliance.org/fonts/NotoSansDisplay-Italic.ttf") format('truetype');
 }
@@ -423,7 +423,7 @@ html.dark {
   font-variation-settings: "wght" 400;
   font-stretch: semi-condensed;
   font-display: block;             /* Prevents FOIT */
-  src: url("/_/boostlook/NotoSansMono.ttf") format("truetype"),
+  src:  url("/static/font/notosans_mono_ext.woff") format("woff"),
        url("../../../../tools/boostlook/NotoSansMono.ttf") format("truetype"),
        url("https://cppalliance.org/fonts/NotoSansMono.ttf") format('truetype');
 }
@@ -435,7 +435,7 @@ html.dark {
   font-weight: 400;                /* Fixed weight for specific use cases */
   font-stretch: ultra-condensed;
   font-display: block;             /* Prevents FOIT */
-  src: url("/_/boostlook/NotoSansMono.ttf") format("truetype"),
+  src:  url("/static/font/notosans_mono.woff") format("woff"),
        url("../../../../tools/boostlook/NotoSansMono.ttf") format("truetype"),
        url("https://cppalliance.org/fonts/NotoSansMono.ttf") format('truetype');
 }


### PR DESCRIPTION
Replace font URLs with WOFF/WOFF2 formats to resolve 404s we got in the v2 project.