### PR TITLE
fix(antora): remove fixed height from doc content

### DIFF
--- a/boostlook.css
+++ b/boostlook.css
@@ -2849,7 +2849,6 @@ html:has(#docsiframe)::-webkit-scrollbar {
 /* Antora template - Scrollable content area */
 .boostlook #content:has(> .doc) {
   overflow-y: auto;
-  height: 100vh;
 }
 
 /* Asciidoc template - Content overflow handling */


### PR DESCRIPTION
Removes 100vh height constraint on Antora document content area to eliminate double scrollbar issue. Content now scrolls naturally without redundant scrollbars.

