### PR TITLE
update font variation settings for better scaling

### DIFF
--- a/boostlook.css
+++ b/boostlook.css
@@ -701,9 +701,9 @@ html:has(.boostlook) {
   font-family: "Noto Sans Display";
   font-style: normal;
   font-weight: 100 900;
+  font-stretch: 62.5% 100%;
   /* Variable font weight range */
-  font-variation-settings: "wght" 400, "wdth" 90;
-  font-stretch: semi-condensed;
+  font-variation-settings: "wght" 400, "wdth" 62.5;
   font-display: block;
   /* Prevents FOIT */
   src: url("/static/font/notosans.woff2") format("woff2"),
@@ -716,9 +716,9 @@ html:has(.boostlook) {
   font-family: "Noto Sans Display";
   font-style: italic;
   font-weight: 100 900;
+  font-stretch: 62.5% 100%;
   /* Variable font weight range */
-  font-variation-settings: "wght" 400, "wdth" 90;
-  font-stretch: semi-condensed;
+  font-variation-settings: "wght" 400, "wdth" 62.5;
   font-display: block;
   /* Prevents FOIT */
   src: url("/static/font/notosans_mono_ext.woff") format("woff"),
@@ -731,9 +731,9 @@ html:has(.boostlook) {
   font-family: "Noto Sans Mono";
   font-style: normal;
   font-weight: 100 900;
+  font-stretch: 62.5% 100%;
   /* Variable font weight range */
-  font-variation-settings: "wght" 400, "wdth" 90;
-  font-stretch: semi-condensed;
+  font-variation-settings: "wght" 400, "wdth" 62.5;
   font-display: block;
   /* Prevents FOIT */
   src: url("/static/font/notosans_mono.woff") format("woff"),
@@ -747,7 +747,7 @@ html:has(.boostlook) {
   font-style: normal;
   font-weight: 400;
   /* Fixed weight for specific use cases */
-  font-stretch: ultra-condensed;
+  font-stretch: 62.5% 100%;
   font-display: block;
   /* Prevents FOIT */
   src: url("/static/font/notosans_mono.woff") format("woff"),
@@ -879,7 +879,7 @@ body :not(pre):not([class^="L"]) > code {
 /* Base Container */
 .boostlook {
   font-family: "Noto Sans Display" !important;
-  font-stretch: 100%;
+  font-variation-settings: "wght" 400, "wdth" 80;
   background: var(--surface-background-main-base-primary, #fff);
 }
 

--- a/boostlook.css
+++ b/boostlook.css
@@ -707,8 +707,8 @@ html:has(.boostlook) {
   font-display: block;
   /* Prevents FOIT */
   src: url("/static/font/notosans.woff2") format("woff2"),
-  url("../../../../tools/boostlook/notosans.woff2") format("truetype"),
-    url("https://cppalliance.org/fonts/NotoSansDisplay.ttf") format("truetype");
+       url("../../../../tools/boostlook/notosans.woff2") format("woff2"),
+       url("https://cppalliance.org/fonts/NotoSansDisplay.ttf") format("truetype");
 }
 
 /* Noto Sans Display - Italic */
@@ -722,8 +722,8 @@ html:has(.boostlook) {
   font-display: block;
   /* Prevents FOIT */
   src: url("/static/font/notosans_mono_ext.woff") format("woff"),
-  url("../../../../tools/boostlook/notosans_mono_ext.woff") format("truetype"),
-    url("https://cppalliance.org/fonts/NotoSansMono.ttf") format("truetype");
+       url("../../../../tools/boostlook/notosans_mono_ext.woff") format("woff"),
+       url("https://cppalliance.org/fonts/NotoSansMono.ttf") format("truetype");
 }
 
 /* Noto Sans Mono - Variable Weight */
@@ -737,8 +737,8 @@ html:has(.boostlook) {
   font-display: block;
   /* Prevents FOIT */
   src: url("/static/font/notosans_mono.woff") format("woff"),
-  url("../../../../tools/boostlook/notosans_mono.woff") format("truetype"),
-    url("https://cppalliance.org/fonts/NotoSansMono.ttf") format("truetype");
+       url("../../../../tools/boostlook/notosans_mono.woff") format("woff"),
+       url("https://cppalliance.org/fonts/NotoSansMono.ttf") format("truetype");
 }
 
 /* Noto Sans Mono - Fixed Weight */
@@ -750,8 +750,9 @@ html:has(.boostlook) {
   font-stretch: ultra-condensed;
   font-display: block;
   /* Prevents FOIT */
-  src: url("/_/boostlook/notosans_mono.woff") format("truetype"), url("../../../../tools/boostlook/notosans_mono.woff") format("truetype"),
-    url("https://cppalliance.org/fonts/NotoSansMono.ttf") format("truetype");
+  src: url("/static/font/notosans_mono.woff") format("woff"),
+       url("../../../../tools/boostlook/notosans_mono.woff") format("woff"),
+       url("https://cppalliance.org/fonts/NotoSansMono.ttf") format("truetype");
 }
 
 /*----------------- Font-Face Declarations end -----------------*/


### PR DESCRIPTION
Updates font variation settings and stretch properties across Noto Sans fonts:
- Changes font-stretch from semi-condensed to 62.5% 100% range
- Updates font-variation-settings wdth from 90 to 62.5
- Adds consistent font-stretch ranges to all font declarations
- Sets base container font-variation-settings to wght 400, wdth 80