### PR TITLE
fix: add overflow-y to document content

### DIFF
--- a/boostlook.css
+++ b/boostlook.css
@@ -3001,6 +3001,7 @@ html:has(#docsiframe)::-webkit-scrollbar {
   margin-right: auto;
   background: var(--surface-background-main-base-primary, #fff);
   position: relative;
+  overflow-y: auto;
 }
 
 /* TOC Common start */


### PR DESCRIPTION
While reviewing boost.url docs, noticed content wasn't scrolling vertically when overflowing container height. Added overflow-y: auto to enable proper scrolling behavior.