### PR TITLE
UI Spacing & Typography Improvements

### DIFF
--- a/boostlook.css
+++ b/boostlook.css
@@ -3894,16 +3894,12 @@ html.dark .boostlook pre.rouge .cm {
   justify-content: center;
   align-items: center;
   color: var(--text-main-text-body-tetriary, #62676b);
-  /*color: var(--colors-neutral-750, #1c1c1c);*/
   font-size: var(--typography-font-size-xs, 0.875rem);
   line-height: var(--typography-line-height-md, 1.25rem); /* 142.857% */
   cursor: pointer;
   border: none;
   background: transparent;
 }
-/*.dark .boostlook .tablist > ul .tab {*/
-/*  color: var(--colors-neutral-250, #f9f9f9);*/
-/*}*/
 
 .boostlook .tabs.is-loading .tablist li:first-child::after,
 .boostlook .tabs:not(.is-loading) .tablist li.is-selected::after {


### PR DESCRIPTION
This PR includes several updates to improve the visual spacing and typography consistency across the documentation:

➕ Added 1.3rem spacing above headers for better separation and readability.
[Screenshot →](https://prnt.sc/wtzXaN00stUT)

🎨 Added background colors:

#f9f9f9 for light mode

#1c1c1c for dark mode
Also set margin-top for these blocks to 1.3rem for consistent spacing.
[Screenshot →](https://prnt.sc/07r8Ha27-jil)
[Screenshot →](https://prnt.sc/Qa3zqGYOqIGy)

📏 Increased spacing between paragraphs from 0.25rem to 1rem for improved text legibility.
[Screenshot →](https://prnt.sc/pu54b-EtLXmY)

🔠 Applied Boostlook font variation settings: changed "wght" axis from 400 to 350 to achieve a slightly lighter typographic weight for better visual harmony.