### PR TITLE
Add disabled state styles for navigation

### DIFF
--- a/boostlook.css
+++ b/boostlook.css
@@ -3789,6 +3789,13 @@ html.dark .boostlook pre.rouge .cm {
   gap: 0.125rem;
 }
 
+.boostlook .toolbar .spirit-nav .disabled,
+.boostlook:not(:has(.doc)) .spirit-nav .disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
 .boostlook:not(:has(.doc)) .spirit-nav {
   padding-top: var(--padding-padding-md, 1.125rem);
   justify-content: flex-end;


### PR DESCRIPTION
### Description
This PR ports over the disabled state styles for navigation from boostorg/website-v2-docs#469

Issue referenced https://github.com/boostorg/website-v2/issues/1837
