### PR TITLE
Fix dark mode background for library readme

### DIFF
--- a/boostlook.css
+++ b/boostlook.css
@@ -1344,8 +1344,10 @@ html.dark .boostlook pre.rouge,
 html.dark .boostlook .doc .content pre,
 html.dark .boostlook .doc pre.highlight,
 html.dark .boostlook .doc .listingblock pre:not(.highlight),
-html.dark .boostlook .doc .literalblock pre {
-  background: var(--atom-one-dark-bg, #282c34);
+html.dark .boostlook .doc .literalblock pre,
+html.dark .boostlook#libraryReadMe > pre:not(:last-child),
+html.dark .boostlook#libraryReadMe div.highlight:has(> pre):not(:is(dd pre, td pre)) {
+  background: var(--atom-one-dark-bg, #282c34) !important;
 }
 
 .boostlook .doc pre {


### PR DESCRIPTION
This PR addresses an issue with the dark mode styling in the library readme, correcting the background color from white to the intended dark background.

[#i836](https://github.com/boostorg/website-v2/issues/1850)

### Preview

<img width="1111" height="985" alt="image" src="https://github.com/user-attachments/assets/8a655026-44da-47c1-9301-b3cc4e8dbb38" />
