### PR TITLE
fix: remove visited link color overrides

### DIFF
--- a/boostlook.css
+++ b/boostlook.css
@@ -1258,12 +1258,6 @@ div.source-docs-antora.boostlook:not(:has(.doc)):not(:has(>.boostlook)) > #conte
   cursor: pointer;
 }
 
-/* Link States */
-.boostlook p a:visited:not(:hover),
-.boostlook table a:visited:not(:hover) {
-  color: var(--text-main-text-body-tetriary, #62676b);
-}
-
 /* Emphasis within code */
 .boostlook em,
 .boostlook code em {


### PR DESCRIPTION
Drop `.boostlook a:visited` so visited links use default color for consistency