### PR TITLE
fix foit: swap, fallbacks, metric overrides (#145)

### DIFF
--- a/boostlook.css
+++ b/boostlook.css
@@ -280,8 +280,8 @@
   --main-container: 90rem;
 
   /* New Look Typography */
-  --font-family-body: "Noto Sans";
-  --font-family-code: "Noto Sans Mono";
+  --font-family-body: "Noto Sans", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  --font-family-code: "Noto Sans Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   --font-size-3xs: 0.625rem;
   --font-size-2xs: 0.75rem;
   --font-size-xs: 0.875rem;
@@ -725,11 +725,15 @@ html:has(.boostlook) {
   font-stretch: 62.5% 100%;
   /* Variable font weight range */
   font-variation-settings: "wght" 400, "wdth" 62.5;
-  font-display: block;
-  /* Prevents FOIT */
+  font-display: swap;
   src: url("/static/font/notosans.woff2") format("woff2"),
   url("../../../../tools/boostlook/notosans.woff2") format("woff2"),
   url("https://cppalliance.org/fonts/NotoSansDisplay.ttf") format("truetype");
+  /* Metric overrides to reduce CLS on swap */
+  size-adjust: 100%;
+  ascent-override: 92%;
+  descent-override: 22%;
+  line-gap-override: 0%;
 }
 
 /* Noto Sans Display - Italic */
@@ -740,11 +744,15 @@ html:has(.boostlook) {
   font-stretch: 62.5% 100%;
   /* Variable font weight range */
   font-variation-settings: "wght" 400, "wdth" 62.5;
-  font-display: block;
-  /* Prevents FOIT */
+  font-display: swap;
   src: url("/static/font/notosans_ext.woff2") format("woff2"),
   url("../../../../tools/boostlook/notosans_ext.woff2") format("woff2"),
   url("https://cppalliance.org/fonts/NotoSansDisplay-Italic.ttf") format("truetype");
+  /* Metric overrides to reduce CLS on swap */
+  size-adjust: 100%;
+  ascent-override: 92%;
+  descent-override: 22%;
+  line-gap-override: 0%;
 }
 
 /* Noto Sans Mono - Variable Weight */
@@ -755,11 +763,15 @@ html:has(.boostlook) {
   font-stretch: 62.5% 100%;
   /* Variable font weight range */
   font-variation-settings: "wght" 400, "wdth" 62.5;
-  font-display: block;
-  /* Prevents FOIT */
+  font-display: swap;
   src: url("/static/font/notosans_mono.woff") format("woff"),
   url("../../../../tools/boostlook/notosans_mono.woff") format("woff"),
   url("https://cppalliance.org/fonts/NotoSansMono.ttf") format("truetype");
+  /* Metric overrides to reduce CLS on swap */
+  size-adjust: 100%;
+  ascent-override: 92%;
+  descent-override: 22%;
+  line-gap-override: 0%;
 }
 
 /* Noto Sans Mono - Fixed Weight */
@@ -769,11 +781,15 @@ html:has(.boostlook) {
   font-weight: 400;
   /* Fixed weight for specific use cases */
   font-stretch: 62.5% 100%;
-  font-display: block;
-  /* Prevents FOIT */
+  font-display: swap;
   src: url("/static/font/notosans_mono.woff") format("woff"),
   url("../../../../tools/boostlook/notosans_mono.woff") format("woff"),
   url("https://cppalliance.org/fonts/NotoSansMono.ttf") format("truetype");
+  /* Metric overrides to reduce CLS on swap */
+  size-adjust: 100%;
+  ascent-override: 92%;
+  descent-override: 22%;
+  line-gap-override: 0%;
 }
 
 /*----------------- Font-Face Declarations end -----------------*/


### PR DESCRIPTION
- use font-display: swap to avoid invisible text
- add system fallbacks for body/code stacks
- add size-adjust/ascent/descent/line-gap to reduce cls (Cumulative Layout Shift)

refs: issue #145