### PR TITLE
fix: change font-display swap to block

### DIFF
--- a/boostlook.css
+++ b/boostlook.css
@@ -725,7 +725,7 @@ html:has(.boostlook) {
   font-stretch: 62.5% 100%;
   /* Variable font weight range */
   font-variation-settings: "wght" 400, "wdth" 62.5;
-  font-display: swap;
+  font-display: block;
   src: url("../font/NotoSansDisplay.ttf") format("truetype"),
   url("/static/font/notosans.woff2") format("woff2"),
   url("../../../../tools/boostlook/notosans.woff2") format("woff2"),
@@ -745,7 +745,7 @@ html:has(.boostlook) {
   font-stretch: 62.5% 100%;
   /* Variable font weight range */
   font-variation-settings: "wght" 400, "wdth" 62.5;
-  font-display: swap;
+  font-display: block;
   src: url("../font/NotoSansDisplay-Italic.ttf") format("truetype"),
   url("/static/font/notosans_ext.woff2") format("woff2"),
   url("../../../../tools/boostlook/notosans_ext.woff2") format("woff2"),
@@ -765,7 +765,7 @@ html:has(.boostlook) {
   font-stretch: 62.5% 100%;
   /* Variable font weight range */
   font-variation-settings: "wght" 400, "wdth" 62.5;
-  font-display: swap;
+  font-display: block;
   src: url("../font/NotoSansMono.ttf") format("truetype"),
   url("/static/font/notosans_mono.woff") format("woff"),
   url("../../../../tools/boostlook/notosans_mono.woff") format("woff"),
@@ -784,7 +784,7 @@ html:has(.boostlook) {
   font-weight: 400;
   /* Fixed weight for specific use cases */
   font-stretch: 62.5% 100%;
-  font-display: swap;
+  font-display: block;
   src: url("../font/NotoSansMono.ttf") format("truetype"),
   url("/static/font/notosans_mono.woff") format("woff"),
   url("../../../../tools/boostlook/notosans_mono.woff") format("woff"),


### PR DESCRIPTION
## Problem
Headers flash system font then swap to Noto Sans

## Solution
Change `font-display: swap` to `font-display: block` for all Noto Sans fonts to prevent text rendering until fonts are loaded.