### PR TITLE
Fix/ios mobile ux 175

### DIFF
--- a/boostlook.css
+++ b/boostlook.css
@@ -1021,6 +1021,18 @@ body :not(pre):not([class^="L"]) > code {
   margin: revert;
 }
 
+/* Scroll offset for anchor links */
+.boostlook .doc h1[id],
+.boostlook .doc h2[id],
+.boostlook .doc h3[id],
+.boostlook .doc h4[id],
+.boostlook .doc h5[id],
+.boostlook .doc h6[id],
+.boostlook .doc :where(h1, h2, h3, h4, h5, h6):has(.anchor),
+.boostlook :where(h1, h2, h3, h4, h5, h6):has(> a[id]) {
+  scroll-margin-top: 0.75rem;
+}
+
 /* Anchor positioning within headings */
 .boostlook .doc h1:has(.anchor),
 .boostlook .doc h2:has(.anchor),
@@ -1161,6 +1173,31 @@ body :not(pre):not([class^="L"]) > code {
   display: inline;
   vertical-align: middle;
   max-width: none;
+}
+
+/* Mobile: always show anchor icons (no hover on touch devices) */
+@media (hover: none) {
+  .boostlook .doc h1 .anchor,
+  .boostlook .doc h2 .anchor,
+  .boostlook .doc h3 .anchor,
+  .boostlook .doc h4 .anchor,
+  .boostlook .doc h5 .anchor,
+  .boostlook .doc h6 .anchor,
+  .boostlook :where(h1, h2, h3, h4, h5, h6):has(> a[id]):has(> a[href]) a[href]:before {
+    opacity: 1 !important;
+    visibility: visible !important;
+  }
+
+  .boostlook .doc h1 .anchor::before,
+  .boostlook .doc h2 .anchor::before,
+  .boostlook .doc h3 .anchor::before,
+  .boostlook .doc h4 .anchor::before,
+  .boostlook .doc h5 .anchor::before,
+  .boostlook .doc h6 .anchor::before,
+  .boostlook :where(h1, h2, h3, h4, h5, h6):has(> a[id]):has(> a[href]) a[href]:after {
+    opacity: 0.6 !important;
+    visibility: visible !important;
+  }
 }
 
 /* Paragraph Styling */
@@ -1613,6 +1650,13 @@ html.dark .boostlook .listingblock > .content > pre {
 .boostlook .content:has(> pre):has(> .source-toolbox):hover .copy-button {
   opacity: 1;
   visibility: visible;
+}
+
+/* Mobile: hide copy button (clipboard API requires HTTPS) */
+@media (hover: none) {
+  .boostlook .content:has(> pre):has(> .source-toolbox) .copy-button {
+    display: none !important;
+  }
 }
 
 .boostlook .content:has(> pre):has(> .source-toolbox) .copy-button img {
@@ -3097,7 +3141,17 @@ html::-webkit-scrollbar-thumb,
 /* Hide root scrollbars for Antora template */
 html:has(.article > .boostlook) {
   height: 100vh;
+  height: -webkit-fill-available;
+  height: 100dvh;
   overflow: hidden;
+}
+
+/* Mobile: remove fixed height + overflow:hidden that conflicts with iOS Safari dynamic toolbar */
+@media (hover: none) and (pointer: coarse) {
+  html:not(.is-clipped--nav):has(.article > .boostlook) {
+    height: auto;
+    overflow: visible;
+  }
 }
 
 /* Iframe container scrollbar handling */
@@ -3114,12 +3168,21 @@ html:has(#docsiframe)::-webkit-scrollbar {
 /* Antora template - Scrollable content area */
 .boostlook #content:has(> .doc) {
   overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Mobile: extra bottom padding to clear iOS Safari toolbar */
+@media (hover: none) and (pointer: coarse) {
+  .boostlook #content:has(> .doc) {
+    padding-bottom: 3.5rem;
+  }
 }
 
 /* Asciidoc template - Content overflow handling */
 .boostlook:has(#content > .sect1) {
   overflow-y: auto;
   height: 100vh;
+  height: 100dvh;
 }
 
 /* Table Container */
@@ -3132,6 +3195,7 @@ html:has(#docsiframe)::-webkit-scrollbar {
 /* Article Layout */
 .article.toc2.toc-left {
   min-height: 100vh;
+  min-height: 100dvh;
   /* Simplified: always use offset behavior, never center */
   margin-left: var(--main-max-width-leftbar);
   background: var(--surface-background-main-base-primary, #fff);
@@ -3302,15 +3366,6 @@ div.source-docs-antora.boostlook:not(:has(article.doc)):not(:has(> .boostlook)) 
   margin-top: revert;
 }
 
-html:not(.is-clipped--nav):has(.boostlook) div#content {
-  display: block;
-  visibility: visible;
-}
-
-html.is-clipped--nav:has(.boostlook) div#content {
-  display: none;
-  visibility: hidden;
-}
 
 /* Responsive Design */
 @media screen and (min-width: 768px) {
@@ -3331,6 +3386,7 @@ html.is-clipped--nav:has(.boostlook) div#content {
     top: 0;
     z-index: 1000;
     height: 100vh;
+    height: 100dvh;
     padding: 0;
     overflow-x: hidden;
     overflow-y: auto;
@@ -3599,6 +3655,7 @@ html.dark .boostlook pre.rouge .cm {
 .boostlook #toc.toc2.nav-container.is-active {
   position: static;
   height: 100vh;
+  height: 100dvh;
   padding: 0;
   overflow-y: auto;
 }
@@ -3980,6 +4037,7 @@ html.dark .boostlook pre.rouge .cm {
   border-radius: 8px;
   min-width: 580px;
   max-height: calc(100vh - 6rem);
+  max-height: calc(100dvh - 6rem);
   overflow: auto;
 }
 
@@ -4156,6 +4214,7 @@ div.source-docs-antora.boostlook {
   overflow: hidden;
   position: relative;
   min-height: 100vh;
+  min-height: 100dvh;
 }
 
 .boostlook#boost-legacy-docs-wrapper > #header,
@@ -4702,6 +4761,7 @@ div.source-docs-antora.boostlook:not(:has(.doc)):not(:has(> .boostlook)) > #cont
     width: var(--main-max-width-leftbar) !important;
     top: 0 !important;
     height: 100vh !important;
+    height: 100dvh !important;
   }
 
   .boostlook #toggle-toc {


### PR DESCRIPTION
## Summary
Fixes #175 — top/bottom of pages inaccessible on iOS Safari.

- Replace `100vh` with `100dvh` (with `-webkit-fill-available` fallback) so viewport height accounts for iOS dynamic toolbars
- On mobile touch devices, remove fixed `height`/`overflow:hidden` on `html` to allow natural scrolling with Safari's dynamic toolbar
- Add bottom padding (`3.5rem`) to content area to clear the iOS Safari bottom toolbar
- Add `scroll-margin-top` to headings so anchor links don't scroll behind the status bar
- Always show heading anchor icons on touch devices via `@media (hover: none)`
- Hide code copy button on mobile (clipboard API requires HTTPS, renders incorrectly over HTTP)
- Remove `is-clipped--nav` content hide/show rules that broke mobile nav link navigation

## Test plan
- [x] iOS Safari (iPhone): scroll to bottom of page — pagination fully visible
- [x] iOS Safari: scroll to top — navigation accessible
- [x] iOS Safari: tap anchor link in TOC — heading scrolls with offset, not behind status bar
- [x] iOS Safari: heading anchor icons visible on touch
- [x] Desktop: no visual regressions, `overflow:hidden` + `100dvh` still active
- [x] Mobile nav: tapping hash links navigates correctly